### PR TITLE
fix: Fix concatenation not allowing type number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export default function urlJoin(...parts) {
 
     // Join parts
     const partsStr = parts
-    .filter((part) => typeof part === 'string')
+    .filter((part) => typeof part === 'string' || typeof part === 'number')
     .join('/');
 
     // Split the parts into beforePathname, pathname, and afterPathname

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -157,3 +157,34 @@ it('should support URLs with relative protocol according to options.protocolRela
     expect(urlJoin('//google.com/foo', 'bar', options)).toBe('/google.com/foo/bar');
     expect(urlJoin('//google.com/foo//', 'bar', options)).toBe('/google.com/foo/bar');
 });
+
+it('should include integers', () => {
+    expect(urlJoin(undefined, 1)).toBe('/1');
+    expect(urlJoin(1, null, 2)).toBe('/1/2');
+    expect(urlJoin(1, '', 2)).toBe('/1/2');
+    expect(urlJoin(1)).toBe('/1');
+    expect(urlJoin('/1')).toBe('/1');
+    expect(urlJoin('/', '/1')).toBe('/1');
+    expect(urlJoin('/', '//1')).toBe('/1');
+    expect(urlJoin('/', '/1//')).toBe('/1');
+    expect(urlJoin('/', '/1/', '')).toBe('/1');
+    expect(urlJoin('/', '/1/', '/')).toBe('/1');
+    expect(urlJoin(1, 2)).toBe('/1/2');
+    expect(urlJoin('/1', 2)).toBe('/1/2');
+    expect(urlJoin('/1', '/2')).toBe('/1/2');
+    expect(urlJoin('/1/', '/2/')).toBe('/1/2');
+    expect(urlJoin('/1/', '/2/3')).toBe('/1/2/3');
+    expect(urlJoin('/1/', '/2//3')).toBe('/1/2/3');
+
+    expect(urlJoin('http://google.com', 1)).toBe('http://google.com/1');
+    expect(urlJoin('http://google.com/', 1)).toBe('http://google.com/1');
+    expect(urlJoin('http://google.com/', '/1')).toBe('http://google.com/1');
+    expect(urlJoin('http://google.com//', '/1')).toBe('http://google.com/1');
+    expect(urlJoin('http://google.com/1', 2)).toBe('http://google.com/1/2');
+
+    expect(urlJoin('http://google.com', '?1')).toBe('http://google.com?1');
+    expect(urlJoin('http://google.com', 'foo?1')).toBe('http://google.com/foo?1');
+    expect(urlJoin('http://google.com', 'foo', '?1')).toBe('http://google.com/foo?1');
+    expect(urlJoin('http://google.com', 'foo/', '?1')).toBe('http://google.com/foo?1');
+    expect(urlJoin('http://google.com?1')).toBe('http://google.com?1');
+});


### PR DESCRIPTION
Currently this package does not allow numbers in parameters, if this is not a security/OS thing (similar packages allow it) I suggest we allow numbers too. Here is a working tested Pull Request.