### PR TITLE
feat: add support to keep leading and trailing slashes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,9 @@ function parseUrl(partsStr, { protocolRelative }) {
     const getParts = (prePathname) =>
         prePathname.split('/').filter((part) => part !== '');
 
-    const hasLeadingSlash = (prePathname) =>
-        prePathname.match(/^\/+/) !== null;
+    const hasLeadingSlash = (prePathname) => RegExp(/^\/+/).test(prePathname);
 
-    const hasTrailingSlash = (prePathname) =>
-        prePathname.match(/\/+$/) !== null;
+    const hasTrailingSlash = (prePathname) => RegExp(/\/+$/).test(prePathname);
 
     const prePathname = match[2] || '';
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,34 +30,9 @@ function parseUrl(partsStr, { protocolRelative }) {
     return { prefix, pathname, suffix };
 }
 
-export default function urlJoin(...parts) {
-    const lastArg = parts[parts.length - 1];
-    let options;
-
-    // If last argument is an object, then it's the options
-    // Note that null is an object, so we verify if is truthy
-    if (lastArg && typeof lastArg === 'object') {
-        options = lastArg;
-        parts = parts.slice(0, -1);
-    }
-
-    // Parse options
-    options = {
-        leadingSlash: true,
-        trailingSlash: false,
-        protocolRelative: false,
-        ...options,
-    };
-
-    // Join parts
-    const partsStr = parts
-    .filter((part) => typeof part === 'string' || typeof part === 'number')
-    .join('/');
-
+function recreateUrl({ prefix, pathname, suffix }, options) {
     // Split the parts into prefix, pathname, and suffix
     // (scheme://host)(/pathnameParts.join('/'))(?queryString)
-    const { prefix, pathname, suffix } = parseUrl(partsStr, options);
-
     const { parts: pathnameParts, hasLeading, hasTrailing } = pathname;
 
     const { leadingSlash, trailingSlash } = options;
@@ -89,4 +64,31 @@ export default function urlJoin(...parts) {
     }
 
     return url;
+}
+
+export default function urlJoin(...parts) {
+    const lastArg = parts[parts.length - 1];
+    let options;
+
+    // If last argument is an object, then it's the options
+    // Note that null is an object, so we verify if is truthy
+    if (lastArg && typeof lastArg === 'object') {
+        options = lastArg;
+        parts = parts.slice(0, -1);
+    }
+
+    // Parse options
+    options = {
+        leadingSlash: true,
+        trailingSlash: false,
+        protocolRelative: false,
+        ...options,
+    };
+
+    // Join parts
+    const partsStr = parts
+    .filter((part) => typeof part === 'string' || typeof part === 'number')
+    .join('/');
+
+    return recreateUrl(parseUrl(partsStr, options), options);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,38 +3,28 @@ import queryString from 'query-string';
 const defaultUrlRegExp = /^(\w+:\/\/[^/?]+)?(.*?)(\?.+)?$/;
 const protocolRelativeUrlRegExp = /^(\/\/[^/?]+)(.*?)(\?.+)?$/;
 
-function parseUrl(partsStr, { protocolRelative, leadingSlash, trailingSlash }) {
+function parseUrl(partsStr, { protocolRelative }) {
     const match = (protocolRelative && partsStr.match(protocolRelativeUrlRegExp)) ||
                    partsStr.match(defaultUrlRegExp) ||
                   [];
 
     const prefix = match[1] || '';
 
+    const getParts = (prePathname) =>
+        prePathname.split('/').filter((part) => part !== '');
+
+    const hasLeadingSlash = (prePathname) =>
+        prePathname.match(/^\/+/) !== null;
+
+    const hasTrailingSlash = (prePathname) =>
+        prePathname.match(/\/+$/) !== null;
+
     const prePathname = match[2] || '';
-
-    const hasLeading = prePathname.match(/^\/+/) !== null;
-    const hasTrailing = prePathname.match(/\/+$/) !== null;
-
-    const getParts = (prePathname) => {
-        const rawParts = prePathname.split('/').filter((part) => part !== '');
-
-        return rawParts.map((part, idx) => {
-            if (leadingSlash === 'keep' && hasLeading && idx === 0) {
-                return `/${part}`;
-            }
-
-            if (trailingSlash === 'keep' && hasTrailing && idx === (rawParts.length - 1)) {
-                return `${part}/`;
-            }
-
-            return part;
-        });
-    };
 
     const pathname = {
         parts: getParts(prePathname),
-        hasLeading,
-        hasTrailing,
+        hasLeading: hasLeadingSlash(prePathname),
+        hasTrailing: hasTrailingSlash(prePathname),
     };
 
     const suffix = (match[3] || '');

--- a/src/index.js
+++ b/src/index.js
@@ -55,24 +55,28 @@ export default function urlJoin(...parts) {
     .join('/');
 
     // Split the parts into prefix, pathname, and suffix
-    // (scheme://host)(/pathname)(?queryString)
+    // (scheme://host)(/pathnameParts.join('/'))(?queryString)
     const { prefix, pathname, suffix } = parseUrl(partsStr, options);
+
+    const { parts: pathnameParts, hasLeading, hasTrailing } = pathname;
+
+    const { leadingSlash, trailingSlash } = options;
 
     let url = '';
 
     // Start with prefix if not empty (http://google.com)
     if (prefix) {
-        url += prefix + (pathname.parts.length > 0 ? '/' : '');
-    // Otherwise start with the leading slash
-    } else if (options.leadingSlash) {
+        url += prefix + (pathnameParts.length > 0 ? '/' : '');
+    // Otherwise start with the leading slash by adding it or keeping it
+    } else if (leadingSlash || (leadingSlash === 'keep' && hasLeading)) {
         url += '/';
     }
 
     // Add pathname (foo/bar)
-    url += pathname.parts.join('/');
+    url += pathnameParts.join('/');
 
-    // Add trailing slash
-    if (options.trailingSlash && !url.endsWith('/')) {
+    // Add trailing slash or keep it
+    if (trailingSlash || (trailingSlash === 'keep' && hasTrailing)) {
         url += '/';
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,9 @@ function splitUrl(partsStr, { protocolRelative, trailingSlash, leadingSlash }) {
 
     const shouldKeep = (opt) => opt === 'keep';
 
-    const removeLeadingSlashes = (s) => s.replace(/^\/+/, '');
+    const removeLeadingSlashes = (pathname) => pathname.replace(/^\/+/, '');
 
-    const removeTrailingSlashes = (s) => s.replace(/\/+$/, '');
+    const removeTrailingSlashes = (pathname) => pathname.replace(/\/+$/, '');
 
     const normalizeConsecutiveSlashesToJustOne = (s) =>
         s.replace(/\/+/g, '/');

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default function urlJoin(...parts) {
     if (beforePathname) {
         url += beforePathname + (pathname ? '/' : '');
     // Otherwise start with the leading slash
-    } else if (options.leadingSlash === true) {
+    } else if (options.leadingSlash) {
         url += '/';
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,14 +64,14 @@ export default function urlJoin(...parts) {
 
     // Start with prefix if not empty (http://google.com)
     if (prefix) {
-        url += prefix + (pathname ? '/' : '');
+        url += prefix + (pathname.parts.length > 0 ? '/' : '');
     // Otherwise start with the leading slash
     } else if (options.leadingSlash) {
         url += '/';
     }
 
     // Add pathname (foo/bar)
-    url += pathname;
+    url += pathname.parts.join('/');
 
     // Add trailing slash
     if (options.trailingSlash && !url.endsWith('/')) {

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ export default function urlJoin(...parts) {
     url += pathname;
 
     // Add trailing slash
-    if (options.trailingSlash === true && !url.endsWith('/')) {
+    if (options.trailingSlash && !url.endsWith('/')) {
         url += '/';
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,20 +14,20 @@ function splitUrl(partsStr, { protocolRelative, trailingSlash, leadingSlash }) {
 
     const shouldKeep = (opt) => opt === 'keep';
 
-    const removeLeadingSlashes = (leadingSlash) =>
-        (s) => shouldKeep(leadingSlash) ? s : s.replace(/^\/+/, '');
+    const removeLeadingSlashes = (s) => s.replace(/^\/+/, '');
 
-    const removeTrailingSlashes = (trailingSlash) =>
-        (s) => shouldKeep(trailingSlash) ? s : s.replace(/\/+$/, '');
+    const removeTrailingSlashes = (s) => s.replace(/\/+$/, '');
 
     const normalizeConsecutiveSlashesToJustOne = (s) =>
         s.replace(/\/+/g, '/');
 
-    const pathname = pipe(
-        removeLeadingSlashes(leadingSlash),
-        removeTrailingSlashes(trailingSlash),
-        normalizeConsecutiveSlashesToJustOne
-    )(match[2] || '');
+    const actions = [
+        !shouldKeep(leadingSlash) && removeLeadingSlashes,
+        !shouldKeep(trailingSlash) && removeTrailingSlashes,
+        normalizeConsecutiveSlashesToJustOne,
+    ].filter(Boolean);
+
+    const pathname = pipe(...actions)(match[2] || '');
 
     const afterPathname = (match[3] || '');
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,14 @@ import queryString from 'query-string';
 const defaultUrlRegExp = /^(\w+:\/\/[^/?]+)?(.*?)(\?.+)?$/;
 const protocolRelativeUrlRegExp = /^(\/\/[^/?]+)(.*?)(\?.+)?$/;
 
+const normalizeParts = (parts) => (
+    // Normalize parts, filtering non-string or non-numeric values
+    parts
+    .filter((part) => typeof part === 'string' || typeof part === 'number')
+    .map((part) => `${part}`)
+    .filter((part) => part)
+);
+
 const parseParts = (parts, options) => {
     const { protocolRelative } = options;
 
@@ -14,8 +22,8 @@ const parseParts = (parts, options) => {
         prefix,
         pathname: {
             parts: pathname.split('/').filter((part) => part !== ''),
-            hasLeading: /^\/+/.test(pathname),
-            hasTrailing: suffix ? /[^/]\/\/+$/.test(pathname) : /[^/]\/+$/.test(pathname),
+            hasLeading: suffix ? /^\/\/+/.test(pathname) : /^\/+/.test(pathname),
+            hasTrailing: suffix ? /\/\/+$/.test(pathname) : /\/+$/.test(pathname),
         },
         suffix,
     };
@@ -79,7 +87,7 @@ const urlJoin = (...parts) => {
     };
 
     // Normalize parts, filtering non-string or non-numeric values
-    parts = parts.filter((part) => typeof part === 'string' || typeof part === 'number');
+    parts = normalizeParts(parts);
 
     // Split the parts into prefix, pathname, and suffix
     // (scheme://host)(/pathnameParts.join('/'))(?queryString)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -225,3 +225,73 @@ it('should handle the provided query and query options objects', () => {
 
     expect(urlJoin('/google.com', options)).toBe('/google.com?foo[0]=1&foo[1]=2&foo[2]=3');
 });
+
+it('should keep the trailing slash', () => {
+    const options = { trailingSlash: 'keep' };
+
+    expect(urlJoin(options)).toBe('/');
+    expect(urlJoin(undefined, 'foo', options)).toBe('/foo');
+    expect(urlJoin('foo', null, 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('foo', '', 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('foo', options)).toBe('/foo');
+    expect(urlJoin('/foo', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo', options)).toBe('/foo');
+    expect(urlJoin('/', '//foo', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo//', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo/', '', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo/', '/', options)).toBe('/foo/');
+    expect(urlJoin('foo', 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo', 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo', '/bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo/', '/bar/', options)).toBe('/foo/bar/');
+    expect(urlJoin('/foo/', '/bar/baz', options)).toBe('/foo/bar/baz');
+    expect(urlJoin('/foo/', '/bar//baz', options)).toBe('/foo/bar/baz');
+
+    expect(urlJoin('http://google.com', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com', '', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com//', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/foo', 'bar', options)).toBe('http://google.com/foo/bar');
+
+    expect(urlJoin('http://google.com', '?queryString', options)).toBe('http://google.com?queryString');
+    expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo/?queryString');
+});
+
+it('should keep the leading slash', () => {
+    const options = { leadingSlash: 'keep' };
+
+    expect(urlJoin(options)).toBe('');
+    expect(urlJoin(undefined, 'foo', options)).toBe('foo');
+    expect(urlJoin('foo', null, 'bar', options)).toBe('foo/bar');
+    expect(urlJoin('foo', '', 'bar', options)).toBe('foo/bar');
+    expect(urlJoin('foo', options)).toBe('foo');
+    expect(urlJoin('/foo', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo', options)).toBe('/foo');
+    expect(urlJoin('/', '//foo', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo//', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo/', '', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo/', '/', options)).toBe('/foo');
+    expect(urlJoin('foo', 'bar', options)).toBe('foo/bar');
+    expect(urlJoin('/foo', 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo', '/bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo/', '/bar/', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo/', '/bar/baz', options)).toBe('/foo/bar/baz');
+    expect(urlJoin('/foo/', '/bar//baz', options)).toBe('/foo/bar/baz');
+
+    expect(urlJoin('http://google.com', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com', '', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com//', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/foo', 'bar', options)).toBe('http://google.com/foo/bar');
+
+    expect(urlJoin('http://google.com', '?queryString', options)).toBe('http://google.com?queryString');
+    expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo/?queryString');
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -229,7 +229,7 @@ it('should handle the provided query and query options objects', () => {
 it('should keep the trailing slash', () => {
     const options = { trailingSlash: 'keep' };
 
-    expect(urlJoin(options)).toBe('');
+    expect(urlJoin(options)).toBe('/');
     expect(urlJoin(undefined, 'foo', options)).toBe('/foo');
     expect(urlJoin('foo', null, 'bar', options)).toBe('/foo/bar');
     expect(urlJoin('foo', '', 'bar', options)).toBe('/foo/bar');

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -20,6 +20,7 @@ it('should add leading slash and no trailing slash by default', () => {
     expect(urlJoin('/foo/', '/bar//baz')).toBe('/foo/bar/baz');
 
     expect(urlJoin('http://google.com')).toBe('http://google.com');
+    expect(urlJoin('http://google.com/')).toBe('http://google.com');
     expect(urlJoin('http://google.com', '')).toBe('http://google.com');
     expect(urlJoin('http://google.com', 'foo')).toBe('http://google.com/foo');
     expect(urlJoin('http://google.com/', 'foo')).toBe('http://google.com/foo');
@@ -56,6 +57,7 @@ it('should add leading slash and trailing slash', () => {
     expect(urlJoin('/foo/', '/bar//baz', options)).toBe('/foo/bar/baz/');
 
     expect(urlJoin('http://google.com', options)).toBe('http://google.com/');
+    expect(urlJoin('http://google.com/', options)).toBe('http://google.com/');
     expect(urlJoin('http://google.com', '', options)).toBe('http://google.com/');
     expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo/');
     expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo/');
@@ -92,6 +94,7 @@ it('should remove leading slash and add trailing slash', () => {
     expect(urlJoin('/foo/', '/bar//baz', options)).toBe('foo/bar/baz/');
 
     expect(urlJoin('http://google.com', options)).toBe('http://google.com/');
+    expect(urlJoin('http://google.com/', options)).toBe('http://google.com/');
     expect(urlJoin('http://google.com', '', options)).toBe('http://google.com/');
     expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo/');
     expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo/');
@@ -128,6 +131,7 @@ it('should remove leading slash and trailing slash', () => {
     expect(urlJoin('/foo/', '/bar//baz', options)).toBe('foo/bar/baz');
 
     expect(urlJoin('http://google.com', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com/', options)).toBe('http://google.com');
     expect(urlJoin('http://google.com', '', options)).toBe('http://google.com');
     expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo');
     expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo');
@@ -226,42 +230,7 @@ it('should handle the provided query and query options objects', () => {
     expect(urlJoin('/google.com', options)).toBe('/google.com?foo[0]=1&foo[1]=2&foo[2]=3');
 });
 
-it('should keep the trailing slash', () => {
-    const options = { trailingSlash: 'keep' };
-
-    expect(urlJoin(options)).toBe('/');
-    expect(urlJoin(undefined, 'foo', options)).toBe('/foo');
-    expect(urlJoin('foo', null, 'bar', options)).toBe('/foo/bar');
-    expect(urlJoin('foo', '', 'bar', options)).toBe('/foo/bar');
-    expect(urlJoin('foo', options)).toBe('/foo');
-    expect(urlJoin('/foo', options)).toBe('/foo');
-    expect(urlJoin('/', '/foo', options)).toBe('/foo');
-    expect(urlJoin('/', '//foo', options)).toBe('/foo');
-    expect(urlJoin('/', '/foo//', options)).toBe('/foo/');
-    expect(urlJoin('/', '/foo/', '', options)).toBe('/foo/');
-    expect(urlJoin('/', '/foo/', '/', options)).toBe('/foo/');
-    expect(urlJoin('foo', 'bar', options)).toBe('/foo/bar');
-    expect(urlJoin('/foo', 'bar', options)).toBe('/foo/bar');
-    expect(urlJoin('/foo', '/bar', options)).toBe('/foo/bar');
-    expect(urlJoin('/foo/', '/bar/', options)).toBe('/foo/bar/');
-    expect(urlJoin('/foo/', '/bar/baz', options)).toBe('/foo/bar/baz');
-    expect(urlJoin('/foo/', '/bar//baz', options)).toBe('/foo/bar/baz');
-
-    expect(urlJoin('http://google.com', options)).toBe('http://google.com');
-    expect(urlJoin('http://google.com', '', options)).toBe('http://google.com');
-    expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo');
-    expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo');
-    expect(urlJoin('http://google.com/', '/foo', options)).toBe('http://google.com/foo');
-    expect(urlJoin('http://google.com//', '/foo', options)).toBe('http://google.com/foo');
-    expect(urlJoin('http://google.com/foo', 'bar', options)).toBe('http://google.com/foo/bar');
-
-    expect(urlJoin('http://google.com', '?queryString', options)).toBe('http://google.com?queryString');
-    expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo?queryString');
-    expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo?queryString');
-    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo/?queryString');
-});
-
-it('should keep the leading slash', () => {
+it('should keep leading slash and remove trailing slash', () => {
     const options = { leadingSlash: 'keep' };
 
     expect(urlJoin(options)).toBe('');
@@ -283,6 +252,7 @@ it('should keep the leading slash', () => {
     expect(urlJoin('/foo/', '/bar//baz', options)).toBe('/foo/bar/baz');
 
     expect(urlJoin('http://google.com', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com/', options)).toBe('http://google.com');
     expect(urlJoin('http://google.com', '', options)).toBe('http://google.com');
     expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo');
     expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo');
@@ -294,4 +264,115 @@ it('should keep the leading slash', () => {
     expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo?queryString');
     expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo?queryString');
     expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo?queryString');
+});
+
+it('should add leading slash and keep trailing slash', () => {
+    const options = { trailingSlash: 'keep' };
+
+    expect(urlJoin(options)).toBe('/');
+    expect(urlJoin(undefined, 'foo', options)).toBe('/foo');
+    expect(urlJoin('foo', null, 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('foo', '', 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('foo', options)).toBe('/foo');
+    expect(urlJoin('/foo', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo', options)).toBe('/foo');
+    expect(urlJoin('/', '//foo', options)).toBe('/foo');
+    expect(urlJoin('/', '/foo//', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo/', '', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo/', '/', options)).toBe('/foo/');
+    expect(urlJoin('foo', 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo', 'bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo', '/bar', options)).toBe('/foo/bar');
+    expect(urlJoin('/foo/', '/bar/', options)).toBe('/foo/bar/');
+    expect(urlJoin('/foo/', '/bar/baz', options)).toBe('/foo/bar/baz');
+    expect(urlJoin('/foo/', '/bar//baz', options)).toBe('/foo/bar/baz');
+
+    expect(urlJoin('http://google.com', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com/', options)).toBe('http://google.com/');
+    expect(urlJoin('http://google.com', '', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com//', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/foo', 'bar', options)).toBe('http://google.com/foo/bar');
+
+    expect(urlJoin('http://google.com', '?queryString', options)).toBe('http://google.com?queryString');
+    expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo/?queryString');
+});
+
+it('should keep leading slash and add trailing slash', () => {
+    const options = { leadingSlash: 'keep', trailingSlash: true };
+
+    expect(urlJoin(options)).toBe('/');
+    expect(urlJoin(undefined, 'foo', options)).toBe('foo/');
+    expect(urlJoin('foo', null, 'bar', options)).toBe('foo/bar/');
+    expect(urlJoin('foo', '', 'bar', options)).toBe('foo/bar/');
+    expect(urlJoin('foo', options)).toBe('foo/');
+    expect(urlJoin('/foo', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo', options)).toBe('/foo/');
+    expect(urlJoin('/', '//foo', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo//', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo/', '', options)).toBe('/foo/');
+    expect(urlJoin('/', '/foo/', '/', options)).toBe('/foo/');
+    expect(urlJoin('foo', 'bar', options)).toBe('foo/bar/');
+    expect(urlJoin('/foo', 'bar', options)).toBe('/foo/bar/');
+    expect(urlJoin('/foo', '/bar', options)).toBe('/foo/bar/');
+    expect(urlJoin('/foo/', '/bar/', options)).toBe('/foo/bar/');
+    expect(urlJoin('/foo/', '/bar/baz', options)).toBe('/foo/bar/baz/');
+    expect(urlJoin('/foo/', '/bar//baz', options)).toBe('/foo/bar/baz/');
+
+    expect(urlJoin('http://google.com', options)).toBe('http://google.com/');
+    expect(urlJoin('http://google.com/', options)).toBe('http://google.com/');
+    expect(urlJoin('http://google.com', '', options)).toBe('http://google.com/');
+    expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo/');
+    expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo/');
+    expect(urlJoin('http://google.com/', '/foo', options)).toBe('http://google.com/foo/');
+    expect(urlJoin('http://google.com//', '/foo', options)).toBe('http://google.com/foo/');
+    expect(urlJoin('http://google.com/foo', 'bar', options)).toBe('http://google.com/foo/bar/');
+
+    expect(urlJoin('http://google.com', '?queryString', options)).toBe('http://google.com/?queryString');
+    expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo/?queryString');
+    expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo/?queryString');
+    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo/?queryString');
+    expect(urlJoin('http://google.com?queryString', options)).toBe('http://google.com/?queryString');
+});
+
+it('should remove leading slash and keep trailing slash', () => {
+    const options = { leadingSlash: false, trailingSlash: 'keep' };
+
+    expect(urlJoin(options)).toBe('');
+    expect(urlJoin(undefined, 'foo', options)).toBe('foo');
+    expect(urlJoin('foo', null, 'bar', options)).toBe('foo/bar');
+    expect(urlJoin('foo', '', 'bar', options)).toBe('foo/bar');
+    expect(urlJoin('foo', options)).toBe('foo');
+    expect(urlJoin('/foo', options)).toBe('foo');
+    expect(urlJoin('/', '/foo', options)).toBe('foo');
+    expect(urlJoin('/', '//foo', options)).toBe('foo');
+    expect(urlJoin('/', '/foo//', options)).toBe('foo/');
+    expect(urlJoin('/', '/foo/', '', options)).toBe('foo/');
+    expect(urlJoin('/', '/foo/', '/', options)).toBe('foo/');
+    expect(urlJoin('foo', 'bar', options)).toBe('foo/bar');
+    expect(urlJoin('/foo', 'bar', options)).toBe('foo/bar');
+    expect(urlJoin('/foo', '/bar', options)).toBe('foo/bar');
+    expect(urlJoin('/foo/', '/bar/', options)).toBe('foo/bar/');
+    expect(urlJoin('/foo/', '/bar/baz', options)).toBe('foo/bar/baz');
+    expect(urlJoin('/foo/', '/bar//baz', options)).toBe('foo/bar/baz');
+
+    expect(urlJoin('http://google.com', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com/', options)).toBe('http://google.com/');
+
+    expect(urlJoin('http://google.com', '', options)).toBe('http://google.com');
+    expect(urlJoin('http://google.com', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', 'foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com//', '/foo', options)).toBe('http://google.com/foo');
+    expect(urlJoin('http://google.com/foo', 'bar', options)).toBe('http://google.com/foo/bar');
+
+    expect(urlJoin('http://google.com', '?queryString', options)).toBe('http://google.com?queryString');
+    expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo?queryString');
+    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo/?queryString');
+    expect(urlJoin('http://google.com?queryString', options)).toBe('http://google.com?queryString');
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -229,7 +229,7 @@ it('should handle the provided query and query options objects', () => {
 it('should keep the trailing slash', () => {
     const options = { trailingSlash: 'keep' };
 
-    expect(urlJoin(options)).toBe('/');
+    expect(urlJoin(options)).toBe('');
     expect(urlJoin(undefined, 'foo', options)).toBe('/foo');
     expect(urlJoin('foo', null, 'bar', options)).toBe('/foo/bar');
     expect(urlJoin('foo', '', 'bar', options)).toBe('/foo/bar');

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -293,5 +293,5 @@ it('should keep the leading slash', () => {
     expect(urlJoin('http://google.com', '?queryString', options)).toBe('http://google.com?queryString');
     expect(urlJoin('http://google.com', 'foo?queryString', options)).toBe('http://google.com/foo?queryString');
     expect(urlJoin('http://google.com', 'foo', '?queryString', options)).toBe('http://google.com/foo?queryString');
-    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo/?queryString');
+    expect(urlJoin('http://google.com', 'foo/', '?queryString', options)).toBe('http://google.com/foo?queryString');
 });


### PR DESCRIPTION
This PR adds support to keep leading and trailing slashes if needed.

The idea here was to create a pipeline of "actions", if you will, that were being used to transform the `pathname`. My reasoning for this came from the need of triggering the `replaces` depending on `trailingSlash` and `leadingSlash` values.

Next steps: 
- unfortunately, I hit some corner cases and a few tests are still failing and I will analyze those soon;
- I still need to add a spec for the following case:
```js
const options = { trailingSlash: 'keep', leadingSlash: 'keep' }
```

